### PR TITLE
Upgrade to angular 14, compilation mode Ivy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ testem.log
 .DS_Store
 Thumbs.db
 /.vscode
+/.vs

--- a/projects/picker/package.json
+++ b/projects/picker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danielmoncada/angular-datetime-picker-moment-adapter",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Angular Date Time Picker (MomentJs Adpater)",
   "keywords": [
     "Angular",
@@ -26,9 +26,9 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@angular/common": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0",
-    "@angular/core": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0",
-    "@angular/cdk": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0",
+    "@angular/common": ">= 8.0.0",
+    "@angular/core": ">= 8.0.0",
+    "@angular/cdk": ">= 8.0.0",
     "moment": "^2.29.1"
   },
   "dependencies": {

--- a/projects/picker/tsconfig.lib.prod.json
+++ b/projects/picker/tsconfig.lib.prod.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.lib.json",
   "angularCompilerOptions": {
-    "enableIvy": false
+    "enableIvy": true,
+    "compilationMode": "partial"
   }
 }


### PR DESCRIPTION
This PR upgrades angular dependency to >= 8 to support angular 14 and also turns on Ivy compilation mode, corrects the warning given by angular cli compilation encouraging authors to turn on Ivy compilation.

Thanks and best regards :)
POFerro